### PR TITLE
Dynamically split multi-tasks based on load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Change Log
 
 ## v0.3 (TBD)
-  - no Sync bound
+  - no `Sync` bound
+  - multi-tasks
   - profiling integration
   - benchmarks
 

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -64,7 +64,6 @@ fn multi_sum() {
     let value_other = Arc::clone(&value);
     let n = 100;
     choir.run_multi_task(n, move |i| {
-        println!("Adding {}", i);
         value_other.fetch_add(i as usize, Ordering::SeqCst);
     });
     choir.wait_idle();


### PR DESCRIPTION
This makes the load automatically balanced if one of the instances takes significantly more time than the other.
It also seamlessly supports changing the worker configuration in-flight.

A benchmark is also added. It shows that the overhead for multi-task is almost twice as large, comparing to individual tasks.