### PR TITLE
Proxy tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Choir is a task orchestration framework. It helps you to organize all the CPU wo
 ```rust
 let choir = choir::Choir::new();
 let _worker = choir.add_worker("worker");
-let task1 = choir.add_task(|| { println!("foo"); });
-let task2 = choir.add_task(|| { println!("bar"); });
+let task1 = choir.add_task(|_| { println!("foo"); });
+let task2 = choir.add_task(|_| { println!("bar"); });
 task2.depend_on(&task1);
 task2.run();
 ```

--- a/apps/dummy.rs
+++ b/apps/dummy.rs
@@ -4,7 +4,7 @@ fn main() {
         .map(|i| choir.add_worker(&format!("worker-{}", i)))
         .collect::<Vec<_>>();
     for _ in 0..1_000_000 {
-        choir.add_task(|| {});
+        choir.spawn("").init(|_| {});
     }
     choir.wait_idle();
 }

--- a/apps/qsort.rs
+++ b/apps/qsort.rs
@@ -72,8 +72,8 @@ unsafe fn qsort(data: Array) {
             ptr: data.ptr.add(right_start),
             count: data.count - right_start,
         };
-        (*CHOIR).add_task(move || qsort(left));
-        (*CHOIR).add_task(move || qsort(right));
+        (*CHOIR).spawn("left").init(move |_| qsort(left));
+        (*CHOIR).spawn("right").init(move |_| qsort(right));
     } else if data.count > 1 {
         insertion_sort(slice::from_raw_parts_mut(data.ptr, data.count))
     }
@@ -98,7 +98,9 @@ fn main() {
         unsafe {
             CHOIR = &choir as *const _;
         }
-        choir.add_task(move || unsafe { qsort(data_raw) });
+        choir
+            .spawn("main")
+            .init(move |_| unsafe { qsort(data_raw) });
         choir.wait_idle();
         unsafe {
             CHOIR = ptr::null();

--- a/benches/ballpark.rs
+++ b/benches/ballpark.rs
@@ -7,7 +7,7 @@ fn many_tasks(c: &mut Criterion) {
         let _worker = choir.add_worker("main");
         b.iter(|| {
             for _ in 0..TASK_COUNT {
-                choir.add_task(|| {});
+                choir.spawn("").init(|_| {});
             }
             choir.wait_idle();
         });
@@ -20,7 +20,7 @@ fn many_tasks(c: &mut Criterion) {
             .collect::<Vec<_>>();
         b.iter(|| {
             for _ in 0..TASK_COUNT {
-                choir.add_task(|| {});
+                choir.spawn("").init(|_| {});
             }
             choir.wait_idle();
         });
@@ -29,7 +29,7 @@ fn many_tasks(c: &mut Criterion) {
         let mut choir = choir::Choir::new();
         let _worker = choir.add_worker("main");
         b.iter(|| {
-            choir.add_multi_task(TASK_COUNT, |_| {});
+            choir.spawn("").init_multi(TASK_COUNT, |_, _| {});
             choir.wait_idle();
         });
     });
@@ -39,7 +39,7 @@ fn many_tasks(c: &mut Criterion) {
             .map(|i| choir.add_worker(&format!("worker-{}", i)))
             .collect::<Vec<_>>();
         b.iter(|| {
-            choir.add_multi_task(TASK_COUNT, |_| {});
+            choir.spawn("").init_multi(TASK_COUNT, |_, _| {});
             choir.wait_idle();
         });
     });

--- a/src/util.rs
+++ b/src/util.rs
@@ -38,7 +38,7 @@ fn smoke() {
     let _worker1 = choir.add_worker("P1");
 
     let data: PerTaskData<u32> = (0..10).collect();
-    choir.add_multi_task(data.len(), move |i| {
+    choir.add_multi_task(data.len(), move |_, i| {
         let v = unsafe { data.take(i) };
         println!("v = {}", v);
     });

--- a/src/util.rs
+++ b/src/util.rs
@@ -38,7 +38,7 @@ fn smoke() {
     let _worker1 = choir.add_worker("P1");
 
     let data: PerTaskData<u32> = (0..10).collect();
-    choir.add_multi_task(data.len(), move |_, i| {
+    choir.spawn("").init_multi(data.len(), move |_, i| {
         let v = unsafe { data.take(i) };
         println!("v = {}", v);
     });

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -16,7 +16,7 @@ fn parallel() {
     // the value. Expect all of them to work.
     for _ in 0..n {
         let v = Arc::clone(&value);
-        choir.add_task(move || {
+        choir.add_task(move |_| {
             v.fetch_add(1, Ordering::AcqRel);
         });
     }
@@ -32,7 +32,7 @@ fn sequential() {
     let _worker = choir.add_worker("S");
 
     let value = Arc::new(Mutex::new(0));
-    let mut base = choir.add_task(move || {});
+    let mut base = choir.add_task(move |_| {});
     let n = 100;
     // Launch N tasks, each depending on the previous one
     // and each setting a value.
@@ -41,7 +41,7 @@ fn sequential() {
     // it has to be N.
     for i in 0..n {
         let v = Arc::clone(&value);
-        let mut next = choir.add_task(move || {
+        let mut next = choir.add_task(move |_| {
             *v.lock().unwrap() = i + 1;
         });
         next.depend_on(&base);
@@ -56,7 +56,7 @@ fn sequential() {
 fn zero_count() {
     let mut choir = choir::Choir::new();
     let _worker1 = choir.add_worker("A");
-    choir.add_multi_task(0, |_| {});
+    choir.add_multi_task(0, |_, _| {});
     choir.wait_idle();
 }
 
@@ -70,7 +70,7 @@ fn multi_sum() {
     let value = Arc::new(AtomicUsize::new(0));
     let value_other = Arc::clone(&value);
     let n = 100;
-    choir.add_multi_task(n, move |i| {
+    choir.add_multi_task(n, move |_, i| {
         value_other.fetch_add(i as usize, Ordering::SeqCst);
     });
     choir.wait_idle();

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -16,7 +16,7 @@ fn parallel() {
     // the value. Expect all of them to work.
     for _ in 0..n {
         let v = Arc::clone(&value);
-        choir.add_task(move |_| {
+        choir.spawn("").init(move |_| {
             v.fetch_add(1, Ordering::AcqRel);
         });
     }
@@ -32,7 +32,7 @@ fn sequential() {
     let _worker = choir.add_worker("S");
 
     let value = Arc::new(Mutex::new(0));
-    let mut base = choir.add_task(move |_| {});
+    let mut base = choir.spawn("").init(move |_| {});
     let n = 100;
     // Launch N tasks, each depending on the previous one
     // and each setting a value.
@@ -41,7 +41,7 @@ fn sequential() {
     // it has to be N.
     for i in 0..n {
         let v = Arc::clone(&value);
-        let mut next = choir.add_task(move |_| {
+        let mut next = choir.spawn("").init(move |_| {
             *v.lock().unwrap() = i + 1;
         });
         next.depend_on(&base);
@@ -56,7 +56,7 @@ fn sequential() {
 fn zero_count() {
     let mut choir = choir::Choir::new();
     let _worker1 = choir.add_worker("A");
-    choir.add_multi_task(0, |_, _| {});
+    choir.spawn("").init_multi(0, |_, _| {});
     choir.wait_idle();
 }
 
@@ -70,7 +70,7 @@ fn multi_sum() {
     let value = Arc::new(AtomicUsize::new(0));
     let value_other = Arc::clone(&value);
     let n = 100;
-    choir.add_multi_task(n, move |_, i| {
+    choir.spawn("").init_multi(n, move |_, i| {
         value_other.fetch_add(i as usize, Ordering::SeqCst);
     });
     choir.wait_idle();
@@ -88,9 +88,37 @@ fn iter_xor() {
     let value_other = Arc::clone(&value);
     let n = 50;
 
-    choir.add_iter_task(0..n, move |item| {
+    choir.spawn("").init_iter(0..n, move |item| {
         value_other.fetch_xor(item, Ordering::SeqCst);
     });
     choir.wait_idle();
     assert_eq!(value.load(Ordering::Acquire), 1);
+}
+
+#[test]
+fn proxy() {
+    let _ = env_logger::try_init();
+    let mut choir = choir::Choir::new();
+    let _worker1 = choir.add_worker("A");
+    let _worker2 = choir.add_worker("B");
+    let choir_arc = Arc::new(choir);
+
+    let value = Arc::new(AtomicUsize::new(0));
+    let choir_other = Arc::clone(&choir_arc);
+    let value_other = Arc::clone(&value);
+    let n = 50;
+    let compute = choir_arc.spawn("parent").init_multi(n, move |notifier, i| {
+        let value_other2 = Arc::clone(&value_other);
+        value_other.fetch_or(1 << i, Ordering::SeqCst);
+        choir_other.spawn_proxy("proxy", notifier).init(move |_| {
+            value_other2.fetch_xor(1 << i, Ordering::SeqCst);
+        });
+    });
+    choir_arc
+        .spawn("test")
+        .init(move |_| {
+            assert_eq!(value.load(Ordering::Acquire), 0);
+        })
+        .depend_on(&compute);
+    choir_arc.wait_idle();
 }


### PR DESCRIPTION
This is a major API breaking change, hopefully an improvement :)
Task creation is now done in 3 steps (instead of 2):
1. `ProtoTask` is created. It has the context information and an ID or a name
2. Function is assigned, and the task becomes an `IdleTask`
3. Dependencies are added, and the task can be ran, becoming `RunningTask`

In addition, all the task functions now receive an extra argument - `&Arc<Notifier>`. This is essentially a task context.
Main motivation for this change was to allow tasks to spawn child tasks from within the executing body. This is now possible: a task can spawn a proxy task using the notifier given as the argument. The proxy can have its own dependencies, since the caller decides when to run it.