### PR TITLE
Redesign forking semantics.

### DIFF
--- a/.github/workflows/pre.yaml
+++ b/.github/workflows/pre.yaml
@@ -14,10 +14,15 @@ jobs:
           toolchain: "1.56.0"
           override: true
       - uses: actions-rs/cargo@v1
-        name: Test all features
+        name: Main check
         with:
           command: check
           args: --workspace
+      - uses: actions-rs/cargo@v1
+        name: Bench compile check
+        with:
+          command: bench
+          args: --no-run
   test:
     name: Test Nightly
     runs-on: ubuntu-latest
@@ -37,11 +42,6 @@ jobs:
         with:
           command: test
           args: --workspace
-      - uses: actions-rs/cargo@v1
-        name: Build the bench
-        with:
-          command: bench
-          args: --no-run
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## v0.5 (TBD)
+## v0.5 (15-08-2022)
   - all functors accept an argument of `ExecutionContext`
   - ability to fork tasks from a functor body
   - `RunningTask::join()` instead of `Choir::wait_all`
@@ -8,6 +8,7 @@
   - `impl Clone for RunningTask`
   - everything implements `Debug`
   - new `Linearc` type for linearized `Arc`
+  - no more spontaneous blocking - the task synchronization is fixed
 
 ### v0.4.2 (07-06-2022)
   - dummy tasks support

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "choir"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2021"
 description = "Task Orchestration Framework"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -10,28 +10,31 @@ Choir is a task orchestration framework. It helps you to organize all the CPU wo
 
 ### Example:
 ```rust
-let choir = choir::Choir::new();
+let mut choir = choir::Choir::new();
 let _worker = choir.add_worker("worker");
-let task1 = choir.add_task(|_| { println!("foo"); });
-let task2 = choir.add_task(|_| { println!("bar"); });
+let task1 = choir.spawn("foo").init_dummy().run();
+let mut task2 = choir.spawn("bar").init(|_| { println!("bar"); });
 task2.depend_on(&task1);
-task2.run();
+task2.run().join();
 ```
 
 ### Selling Pitch
 
 What makes Choir _elegant_? Generally when we need to encode the semantics of "wait for dependencies", we think of some sort of a counter. Maybe an atomic, for the dependency number. When it reaches zero (or one), we schedule a task for execution. In _Choir_, the internal data for a task (i.e. the functor itself!) is placed in an `Arc`. Whenever we are able to extract it from the `Arc` (which means there are no other dependencies), we move it to a scheduling queue. I think Rust type system shows its best here.
 
-You can add or remove workers at any time to balance the system load, which may be running other applications at the same time.
+Note: it turns out `Arc` doesn't fully support such a "linear" usage as required here, and it's impossible to control where the last reference gets destructed (without logic in `drop()`). For this reason, we introduce our own `Linearc` to be used internally.
+
+You can also add or remove workers at any time to balance the system load, which may be running other applications at the same time.
 
 ## API
 
 General workflow is about creating tasks and setting up dependencies between them. There is a few different kinds of tasks:
-  - single-run tasks, created with `add_task()` and represented as `FnOnce()`
-  - multi-run tasks, executed for every index in a range, represented as `Fn(SubIndex)`, and created with `add_multi_task()`
-  - iteration tasks, executed for every item produced by an iterator, represented as `Fn(T)`, and created with `add_iter_task()`
+  - single-run tasks, initialized with `init()` and represented as `FnOnce()`
+  - dummy tasks, initialized with `init_dummy()`, and having no function body
+  - multi-run tasks, executed for every index in a range, represented as `Fn(SubIndex)`, and initialized with `init_multi()`
+  - iteration tasks, executed for every item produced by an iterator, represented as `Fn(T)`, and initialized with `init_iter()`
 
-Just calling `add_xxx()` is equivalent of following up with `IdleTask::run()` on the returned object.
+Just calling `run()` is done automatically on `IdleTask::drop()` if not called explicitly.
 This object also allows adding dependencies before scheduling the task. The running task can be also used as a dependency for others.
 
 Note that all tasks are pre-empted at the `Fn()` execution boundary. Thus, for example, a long-running multi task will be pre-empted by any incoming single-run tasks.
@@ -45,7 +48,7 @@ Note that all tasks are pre-empted at the `Fn()` execution boundary. Thus, for e
 
 Machine: MBP 2016, 3.3 GHz Dual-Core Intel Core i7
 
-- function `add_task` (optimized): 237ns
+- functions `spawn()+init()` (optimized): 237ns
 - "steal" task: 61ns
 - empty "execute": 37ns
 - dummy "unblock": 78ns

--- a/apps/qsort.rs
+++ b/apps/qsort.rs
@@ -3,8 +3,6 @@ use std::{ptr, slice};
 
 type Value = i64;
 
-static mut CHOIR: *const choir::Choir = ptr::null();
-
 #[derive(Clone, Copy)]
 struct Array {
     ptr: *mut Value,
@@ -97,21 +95,11 @@ fn main() {
         let mut choir = choir::Choir::new();
         let _worker1 = choir.add_worker("worker1");
         let _worker2 = choir.add_worker("worker2");
-        unsafe {
-            CHOIR = &choir as *const _;
-        }
-        let main = choir
+        choir
             .spawn("main")
-            .init(move |ec| unsafe { qsort(data_raw, ec) });
-
-        let mut done = choir.spawn("done").init_dummy();
-        done.depend_on(&main);
-        main.run();
-        done.run().join();
-
-        unsafe {
-            CHOIR = ptr::null();
-        }
+            .init(move |ec| unsafe { qsort(data_raw, ec) })
+            .run()
+            .join();
     } else {
         insertion_sort(&mut data);
     }


### PR DESCRIPTION
Fixes #22

Previously, forking meant just copying over the list of dependents.
Now, instead, it's a task with its own list of dependents,
which is blocking the *finalization* of the current task.