### PR TITLE
Relax forked tasks lifetimes

### DIFF
--- a/apps/qsort.rs
+++ b/apps/qsort.rs
@@ -1,16 +1,7 @@
 use rand::Rng as _;
-use std::{ptr, slice};
+use std::{mem, ptr};
 
 type Value = i64;
-
-#[derive(Clone, Copy)]
-struct Array {
-    ptr: *mut Value,
-    count: usize,
-}
-
-// Not sure why Rust doesn't consider pointers movable?
-unsafe impl Send for Array {}
 
 fn insertion_sort(data: &mut [Value]) {
     for i in 1..data.len() {
@@ -29,51 +20,45 @@ fn insertion_sort(data: &mut [Value]) {
     }
 }
 
-unsafe fn split(data: Array) -> (usize, usize) {
-    let mid = *data.ptr;
+unsafe fn split(data: &mut [Value]) -> (&mut [Value], &mut [Value]) {
+    let mid = data[0];
     let mut i = 1;
-    let mut j = data.count - 1;
+    let mut j = data.len() - 1;
     'outer: while i < j {
-        while *data.ptr.add(i) <= mid {
+        while data[i] <= mid {
             i += 1;
             if i == j {
                 break 'outer;
             }
         }
-        while *data.ptr.add(j) > mid {
+        while data[j] > mid {
             j -= 1;
             if i == j {
                 break 'outer;
             }
         }
-        ptr::swap(&mut *data.ptr.add(i), &mut *data.ptr.add(j));
+        ptr::swap(&mut data[i], &mut data[j]);
         i += 1;
         j -= 1;
     }
+
+    let (left, right) = data.split_at_mut(j);
     // guarantee that the element in the middle can be excluded
-    if *data.ptr.add(j) <= mid {
-        ptr::swap(&mut *data.ptr, &mut *data.ptr.add(j));
-        (j, j + 1)
+    if right[0] <= mid {
+        mem::swap(&mut left[0], &mut right[0]);
+        (left, right.split_first_mut().unwrap().1)
     } else {
-        (j, j)
+        (left, right)
     }
 }
 
-unsafe fn qsort(data: Array, context: choir::ExecutionContext) {
-    if data.count > 5 {
-        let (left_end, right_start) = split(data);
-        let left = Array {
-            ptr: data.ptr,
-            count: left_end,
-        };
-        let right = Array {
-            ptr: data.ptr.add(right_start),
-            count: data.count - right_start,
-        };
+unsafe fn qsort(data: &mut [Value], context: choir::ExecutionContext) {
+    if data.len() > 5 {
+        let (left, right) = split(data);
         context.fork("left").init(move |ec| qsort(left, ec));
         context.fork("right").init(move |ec| qsort(right, ec));
-    } else if data.count > 1 {
-        insertion_sort(slice::from_raw_parts_mut(data.ptr, data.count))
+    } else if data.len() > 1 {
+        insertion_sort(data)
     }
 }
 
@@ -88,16 +73,13 @@ fn main() {
     };
 
     if USE_TASKS {
-        let data_raw = Array {
-            ptr: data.as_mut_ptr(),
-            count: COUNT,
-        };
         let mut choir = choir::Choir::new();
         let _worker1 = choir.add_worker("worker1");
         let _worker2 = choir.add_worker("worker2");
+        let data_slice = data.as_mut_slice();
         choir
             .spawn("main")
-            .init(move |ec| unsafe { qsort(data_raw, ec) })
+            .init(move |ec| unsafe { qsort(data_slice, ec) })
             .run()
             .join();
     } else {


### PR DESCRIPTION
This PR introduces a mechanism for having non-static task bodies. In particular, when forking tasks, we can guarantee that their closures will die before the parent closure dies. This drastically improves the `qsort` case ergonomics.

Draft because it needs a careful look at safety, and doesn't work yet:
```
thread 'worker1' panicked at 'called `Option::unwrap()` on a `None` value', src/lib.rs:267:26
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: PoisonError { .. }', src/lib.rs:510:50
thread 'worker2' panicked at 'called `Result::unwrap()` on an `Err` value: PoisonError { .. }', src/lib.rs:260:58
```