### PR TITLE
Run attached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## v0.6 (TBD)
+  - redesigned fork semantics that's more robust and supports `join()`
+  - support non-`'static` function bodies via `run_attached()`
+  - truly joining the choir when waiting on a task via `join_active()`
+  - always use `Arc<Choir>`
+
 ## v0.5 (15-08-2022)
   - all functors accept an argument of `ExecutionContext`
   - ability to fork tasks from a functor body

--- a/apps/dummy.rs
+++ b/apps/dummy.rs
@@ -8,5 +8,5 @@ fn main() {
         let task = choir.spawn("").init_dummy();
         end.depend_on(&task);
     }
-    end.run().join();
+    end.run_attached();
 }

--- a/apps/dummy.rs
+++ b/apps/dummy.rs
@@ -1,5 +1,5 @@
 fn main() {
-    let mut choir = choir::Choir::new();
+    let choir = choir::Choir::new();
     let _workers = (0..2)
         .map(|i| choir.add_worker(&format!("worker-{}", i)))
         .collect::<Vec<_>>();

--- a/apps/qsort.rs
+++ b/apps/qsort.rs
@@ -75,7 +75,7 @@ fn main() {
     };
 
     if USE_TASKS {
-        let mut choir = choir::Choir::new();
+        let choir = choir::Choir::new();
         let _worker1 = choir.add_worker("worker1");
         let _worker2 = choir.add_worker("worker2");
         let data_slice = data.as_mut_slice();

--- a/src/util.rs
+++ b/src/util.rs
@@ -34,9 +34,7 @@ impl<T> FromIterator<T> for PerTaskData<T> {
 
 #[test]
 fn smoke() {
-    let mut choir = super::Choir::new();
-    let _worker1 = choir.add_worker("P1");
-
+    let choir = super::Choir::new();
     let data: PerTaskData<u32> = (0..10).collect();
     choir
         .spawn("")
@@ -44,6 +42,5 @@ fn smoke() {
             let v = unsafe { data.take(i) };
             println!("v = {}", v);
         })
-        .run()
-        .join();
+        .run_attached();
 }


### PR DESCRIPTION
This is a different attempt to support non-static lifetimes, a successor to #26. It's more limited (can't borrow from the parent task body), but sound.
Like #26, it makes the `qsort` app look really nice, with no unsafe any more!
It also fixes an important correctness issue with `finish()` that landed somehow.

Now includes the removal of `Conductor` as a separate concept internally.
And as an icing on the cake, allows joining the execution in an active mode.