### PR TITLE
Panic after join() if any tasks have panicked

### DIFF
--- a/.github/workflows/pre.yaml
+++ b/.github/workflows/pre.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: "1.56.0"
+          toolchain: "1.60.0"
           override: true
       - uses: actions-rs/cargo@v1
         name: Main check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   - support non-`'static` function bodies via `run_attached()`
   - truly joining the choir when waiting on a task via `join_active()`
   - always use `Arc<Choir>`
+  - propagate panics from the tasks/workers
 
 ## v0.5 (15-08-2022)
   - all functors accept an argument of `ExecutionContext`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   - truly joining the choir when waiting on a task via `join_active()`
   - always use `Arc<Choir>`
   - propagate panics from the tasks/workers
+  - MSRV bumped to 1.60
 
 ## v0.5 (15-08-2022)
   - all functors accept an argument of `ExecutionContext`

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -166,3 +166,11 @@ fn multi_thread_join() {
     t1.join().unwrap();
     t2.join().unwrap();
 }
+
+#[test]
+#[should_panic]
+fn task_panic() {
+    let choir = choir::Choir::new();
+    let _w = choir.add_worker("main");
+    choir.spawn("task").init(|_| panic!("Oops!")).run().join();
+}


### PR DESCRIPTION
This is an approach to handling panics. It's better than nothing, but ideally we'd also propagate the whole panic context up.