### PR TITLE
Expose the owner task processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   - truly joining the choir when waiting on a task via `join_active()`
   - always use `Arc<Choir>`
   - propagate panics from the tasks/workers
+  - expose `choir` in the tasks and execution contexts
   - MSRV bumped to 1.60
 
 ## v0.5 (15-08-2022)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ pub struct ExecutionContext<'a> {
     worker_index: isize,
 }
 
-impl ExecutionContext<'_> {
+impl<'a> ExecutionContext<'a> {
     /// Get the running task handle of the current task.
     pub fn self_task(&self) -> RunningTask {
         RunningTask {
@@ -97,6 +97,12 @@ impl ExecutionContext<'_> {
             notifier: Arc::clone(self.notifier),
         }
     }
+
+    /// Return the main choir.
+    pub fn choir(&self) -> &'a Arc<Choir> {
+        self.choir
+    }
+
     /// Fork the current task.
     ///
     /// This is useful because it allows creating tasks on the fly from within


### PR DESCRIPTION
The idea is: once something is *exposed* to the task processor, either by getting an `ExecutionContext`, or a terminal task, it shouldn't need to get the `choir` argument in addition on that. `Choir` becomes a transient global: it's accessible where it needs to be accessible, but without the boilerplate to pass it around everywhere.

Note: the scope of the PR is reduced to only expose it on the execution context, and do it as an accessor method.