### PR TITLE
Add `ExecutionContext::add_fork` API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Change Log
 
 ## v0.6 (TBD)
-  - redesigned fork semantics that's more robust and supports `join()`
+  - redesign fork semantics that's more robust and supports `join()`
+  - add an ability to add an existing task as a fork
   - support non-`'static` function bodies via `run_attached()`
   - truly joining the choir when waiting on a task via `join_active()`
   - always use `Arc<Choir>`

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -136,6 +136,36 @@ fn proxy() {
 }
 
 #[test]
+fn fork_in_flight() {
+    let _ = env_logger::try_init();
+    let choir = choir::Choir::new();
+    let _worker1 = choir.add_worker("A");
+    let value = Arc::new(AtomicUsize::new(0));
+    let value1 = Arc::clone(&value);
+    // This task deliberately waits, so that we know for sure
+    // if it's being waited on.
+    let t1 = choir
+        .spawn("child")
+        .init(move |_| {
+            thread::sleep(Duration::from_millis(10));
+            value1.fetch_add(1, Ordering::AcqRel);
+        })
+        .run();
+    let value2 = Arc::clone(&value);
+    // This task decides to add `t1` as a fork, which is already in flight.
+    let t2 = choir.spawn("parent").init(move |ec| {
+        value2.fetch_add(1, Ordering::AcqRel);
+        ec.add_fork(&t1);
+    });
+    // This is the dependent task, it will have to wait for both.
+    let mut t3 = choir.spawn("finish").init_dummy();
+    t3.depend_on(&t2);
+    t2.run();
+    t3.run().join();
+    assert_eq!(value.load(Ordering::Acquire), 2);
+}
+
+#[test]
 fn unhelpful() {
     let choir = choir::Choir::new();
     let mut done = false;


### PR DESCRIPTION
This is useful when you aren't directly creating a task that needs to be treated as a fork.