### PR TITLE
Use a single condvar/mutex pair for synchronization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - always use `Arc<Choir>`
   - propagate panics from the tasks/workers
   - expose `choir` in the tasks and execution contexts
+  - `Condvar`-based thread blocking
   - MSRV bumped to 1.60
 
 ## v0.5 (15-08-2022)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ harness = false
 
 [dependencies]
 crossbeam-deque = "0.8"
-crossbeam-utils = "0.8"
 log = "0.4"
 profiling = "1"
 

--- a/benches/ballpark.rs
+++ b/benches/ballpark.rs
@@ -9,6 +9,7 @@ fn work(n: choir::SubIndex) {
 
 fn many_tasks(c: &mut Criterion) {
     const TASK_COUNT: choir::SubIndex = 1_000;
+    //let _ = profiling::tracy_client::Client::start();
     let choir = choir::Choir::new();
     if true {
         let _worker = choir.add_worker("main");


### PR DESCRIPTION
Perf-wise I don't see much difference:
Old:
```
individual tasks: single worker
                        time:   [1.6127 ms 1.6222 ms 1.6316 ms]
                        change: [-6.0241% -5.2214% -4.3739%] (p = 0.00 < 0.05)

multi-task: single worker
                        time:   [1.0690 ms 1.0743 ms 1.0796 ms]
                        change: [-3.0450% -1.0601% +1.5580%] (p = 0.43 > 0.05)

individual tasks: 8 workers
                        time:   [713.70 µs 720.72 µs 727.99 µs]
                        change: [-8.5857% -6.8229% -4.9356%] (p = 0.00 < 0.05)

multi-task: 8 workers   time:   [305.64 µs 307.27 µs 308.94 µs]
                        change: [-6.7217% -5.5816% -4.4155%] (p = 0.00 < 0.05)
```
New:
```
individual tasks: single worker
                        time:   [1.6806 ms 1.6903 ms 1.7003 ms]
                        change: [-94.953% -94.909% -94.867%] (p = 0.00 < 0.05)

multi-task: single worker
                        time:   [1.0850 ms 1.0931 ms 1.1016 ms]
                        change: [-75.084% -74.816% -74.527%] (p = 0.00 < 0.05)

individual tasks: 8 workers
                        time:   [769.29 µs 780.39 µs 791.85 µs]
                        change: [+1.2185% +3.2096% +5.0820%] (p = 0.00 < 0.05)

multi-task: 8 workers   time:   [318.11 µs 321.61 µs 325.37 µs]
                        change: [-94.604% -94.527% -94.441%] (p = 0.00 < 0.05)
```

However, it simplifies things quite a bit. There is less mutexes around, less obscure logic of waking up threads. It's much nicer internally.