### PR TITLE
Upgrade join() mechanics and API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.7 (TBD)
   - make `join()` to work with `&self`
+  - reimplement `join()` in a robust way
 
 ## v0.6 (30-05-2023)
   - redesign fork semantics that's more robust and supports `join()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## v0.7 (TBD)
+  - make `join()` to work with `&self`
+
 ## v0.6 (30-05-2023)
   - redesign fork semantics that's more robust and supports `join()`
   - add an ability to add an existing task as a fork

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -681,7 +681,7 @@ impl RunningTask {
 
     /// Block until the task has finished executing.
     #[profiling::function]
-    pub fn join(self) -> MaybePanic {
+    pub fn join(&self) -> MaybePanic {
         log::debug!("Joining {}", self.notifier);
         match *self.notifier.continuation.lock().unwrap() {
             Some(ref mut cont) => {
@@ -701,7 +701,7 @@ impl RunningTask {
     /// Block until the task has finished executing.
     /// Also, use the current thread to help in the meantime.
     #[profiling::function]
-    pub fn join_active(self) -> MaybePanic {
+    pub fn join_active(&self) -> MaybePanic {
         match *self.notifier.continuation.lock().unwrap() {
             Some(ref mut cont) => {
                 cont.waiting_threads.push(thread::current());
@@ -725,7 +725,7 @@ impl RunningTask {
 
     /// Block until the task has finished executing, with timeout.
     /// Panics and prints helpful info if the timeout is reached.
-    pub fn join_debug(self, timeout: time::Duration) -> MaybePanic {
+    pub fn join_debug(&self, timeout: time::Duration) -> MaybePanic {
         log::debug!("Joining {}", self.notifier);
         match *self.notifier.continuation.lock().unwrap() {
             Some(ref mut cont) => {

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -189,9 +189,9 @@ fn multi_thread_join() {
         })
         .run();
     let r1 = running.clone();
-    let t1 = thread::spawn(|| r1.join());
+    let t1 = thread::spawn(move || r1.join());
     let r2 = running.clone();
-    let t2 = thread::spawn(|| r2.join());
+    let t2 = thread::spawn(move || r2.join());
     t1.join().unwrap();
     t2.join().unwrap();
 }


### PR DESCRIPTION
There was a race condition in `zero_count()` test. Parking is unreliable. The new implementation uses conditional variables instead.