### PR TITLE
Disable task lifetimes

### DIFF
--- a/benches/ballpark.rs
+++ b/benches/ballpark.rs
@@ -17,7 +17,7 @@ fn many_tasks(c: &mut Criterion) {
             b.iter(|| {
                 let mut parent = choir.spawn("parent").init_dummy();
                 for i in 0..TASK_COUNT {
-                    let task = choir.spawn("").init(|_| work(i));
+                    let task = choir.spawn("").init(move |_| work(i));
                     parent.depend_on(&task);
                 }
                 parent.run().join();
@@ -27,7 +27,7 @@ fn many_tasks(c: &mut Criterion) {
             b.iter(|| {
                 choir
                     .spawn("")
-                    .init_multi(TASK_COUNT, |_, i| work(i))
+                    .init_multi(TASK_COUNT, move |_, i| work(i))
                     .run()
                     .join();
             });
@@ -43,7 +43,7 @@ fn many_tasks(c: &mut Criterion) {
             b.iter(|| {
                 let mut parent = choir.spawn("parent").init_dummy();
                 for i in 0..TASK_COUNT {
-                    let task = choir.spawn("").init(|_| work(i));
+                    let task = choir.spawn("").init(move |_| work(i));
                     parent.depend_on(&task);
                 }
                 parent.run().join();
@@ -53,7 +53,7 @@ fn many_tasks(c: &mut Criterion) {
             b.iter(|| {
                 choir
                     .spawn("")
-                    .init_multi(TASK_COUNT, |_, i| work(i))
+                    .init_multi(TASK_COUNT, move |_, i| work(i))
                     .run()
                     .join();
             });


### PR DESCRIPTION
Found a safe&sound issue with lifetimes. If a task borrows something (having non-static lifetime), the original idea was that you could only `run_attached` it. However, if the `IdleTask` is dropped, the system was happy to defer its execution automatically for later. This is a part of the idea that `IdleTask` gets executed no matter what.

Unfortunately, we can't determine at run-time what the (compile!) lifetime is. The basic reasoning here is that the lifetimes are supposed to be compiler annotations, and be non-semantical. They can only prevent something from compiling, but do not actually affect the compiled code.

Worth noting that I wanted to have the borrowing tasks in order to support fork-join parallelism aka `rayon`. But it's not the main use case. So now this use case is dropped entirely, since it wasn't safe.

Related to #26 and #27