### PR TITLE
Support multiple parents of a fork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   - reimplement `join()` in a robust way
   - remove non-static tasks
   - fix multiple race conditions
+  - allow multiple parents of a task
 
 ## v0.6 (30-05-2023)
   - redesign fork semantics that's more robust and supports `join()`

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -227,6 +227,14 @@ fn multi_thread_join() {
 
 #[test]
 #[should_panic]
+fn join_timeout() {
+    let choir = choir::Choir::new();
+    let task = choir.spawn("test").init_dummy();
+    task.run().join_debug(Default::default());
+}
+
+#[test]
+#[should_panic]
 fn task_panic() {
     let choir = choir::Choir::new();
     let _w = choir.add_worker("main");


### PR DESCRIPTION
What happens in Blade is: each resource gets associated with a load task. When we are *serving* the higher level resources that depend on this one, we add them as a parent to this one. So we may end up with more than one "parent" for any give resource. It functions as a "completion dependency" as opposed to "start dependency", which the regular dependency is.