### PR TITLE
Add Loom CI job to pre-merge checks

### DIFF
--- a/.github/workflows/pre.yaml
+++ b/.github/workflows/pre.yaml
@@ -35,6 +35,14 @@ jobs:
           components: miri
       - name: Miri test
         run: cargo miri test --workspace
+  loom:
+    name: Loom
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Loom test
+        run: RUSTFLAGS='--cfg loom' cargo test --test loom --release
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ repository = "https://github.com/kvark/choir"
 keywords = ["job-system", "tasks"]
 categories = ["concurrency", "game-development"]
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)'] }
+
 [workspace]
 members = [
 	"apps",
@@ -24,7 +27,11 @@ crossbeam-deque = "0.8"
 log = "0.4"
 profiling = "1"
 
+[target.'cfg(loom)'.dependencies]
+loom = "0.7"
+
 [dev-dependencies]
 criterion = "0.5"
 env_logger = "0.9"
+loom = "0.7"
 num_cpus = "1"

--- a/README.md
+++ b/README.md
@@ -45,7 +45,17 @@ Note that all tasks are pre-empted at the `Fn()` execution boundary. Thus, for e
 
 ### TODO:
   - detect when dependencies aren't set up correctly
-  - test with [Loom](https://github.com/tokio-rs/loom): blocked by https://github.com/crossbeam-rs/crossbeam/pull/849
+
+### Testing with [Loom](https://github.com/tokio-rs/loom)
+
+Loom tests use a `Mutex<VecDeque>` queue in place of `crossbeam-deque::Injector`
+(loom support in crossbeam-deque is still pending: https://github.com/crossbeam-rs/crossbeam/pull/849).
+This lets loom verify all the other synchronization logic (`Linearc` atomics,
+`Condvar`/`Mutex` interactions, dependency resolution).
+
+```sh
+RUSTFLAGS='--cfg loom' cargo test --test loom --release
+```
 
 ## Overhead
 

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -1,8 +1,5 @@
-use std::{
-    fmt, mem, ops,
-    ptr::NonNull,
-    sync::atomic::{AtomicUsize, Ordering},
-};
+use crate::compat::{AtomicUsize, Ordering};
+use std::{fmt, mem, ops, ptr::NonNull};
 
 /// Note: `pub(super)` is only needed for a hack
 #[derive(Debug)]

--- a/src/compat.rs
+++ b/src/compat.rs
@@ -1,0 +1,45 @@
+//! Compatibility layer for testing with [Loom](https://github.com/tokio-rs/loom).
+//!
+//! Under `cfg(loom)`, re-exports synchronization primitives from `loom`.
+//! Otherwise, re-exports from `std`.
+//!
+//! Note: `Arc` is always re-exported from `std` because loom's `Arc` does not
+//! support `self: &Arc<Self>` method receivers or `Display`. The concurrency
+//! bugs we care about live in the Mutex/Condvar/atomic interactions, not `Arc`.
+
+pub(crate) use std::sync::Arc;
+
+#[cfg(not(loom))]
+pub(crate) use std::sync::{
+    atomic::{AtomicBool, AtomicUsize, Ordering},
+    Condvar, Mutex, MutexGuard, RwLock,
+};
+
+#[cfg(loom)]
+pub(crate) use loom::sync::{
+    atomic::{AtomicBool, AtomicUsize, Ordering},
+    Condvar, Mutex, MutexGuard, RwLock,
+};
+
+/// `Condvar::wait_while` wrapper — loom's `Condvar` does not provide `wait_while`.
+#[cfg(not(loom))]
+pub(crate) fn wait_while<'a, T>(
+    condvar: &Condvar,
+    guard: MutexGuard<'a, T>,
+    condition: impl FnMut(&mut T) -> bool,
+) -> MutexGuard<'a, T> {
+    condvar.wait_while(guard, condition).unwrap()
+}
+
+/// `Condvar::wait_while` polyfill for loom.
+#[cfg(loom)]
+pub(crate) fn wait_while<'a, T>(
+    condvar: &Condvar,
+    mut guard: MutexGuard<'a, T>,
+    mut condition: impl FnMut(&mut T) -> bool,
+) -> MutexGuard<'a, T> {
+    while condition(&mut *guard) {
+        guard = condvar.wait(guard).unwrap();
+    }
+    guard
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,15 +42,13 @@ pub(crate) mod queue;
 pub mod util;
 
 use self::arc::Linearc;
-use crate::compat::{
-    wait_while, Arc, AtomicBool, AtomicUsize, Condvar, Mutex, Ordering, RwLock,
-};
+use crate::compat::{wait_while, Arc, AtomicBool, AtomicUsize, Condvar, Mutex, Ordering, RwLock};
 use crate::queue::{Injector, Steal};
-use std::{borrow::Cow, fmt, mem, ops, sync::atomic::AtomicIsize, time};
-#[cfg(not(loom))]
-use std::thread;
 #[cfg(loom)]
 use loom::thread;
+#[cfg(not(loom))]
+use std::thread;
+use std::{borrow::Cow, fmt, mem, ops, sync::atomic::AtomicIsize, time};
 
 const BITS_PER_BYTE: usize = 8;
 const MAX_WORKERS: usize = size_of::<usize>() * BITS_PER_BYTE;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,20 +36,21 @@ Lifetime of a Task:
 
 /// Better shared pointer.
 pub mod arc;
+pub(crate) mod compat;
+pub(crate) mod queue;
 /// Additional utilities.
 pub mod util;
 
 use self::arc::Linearc;
-use crossbeam_deque::{Injector, Steal};
-use std::{
-    borrow::Cow,
-    fmt, mem, ops,
-    sync::{
-        atomic::{AtomicBool, AtomicIsize, AtomicUsize, Ordering},
-        Arc, Condvar, Mutex, RwLock,
-    },
-    thread, time,
+use crate::compat::{
+    wait_while, Arc, AtomicBool, AtomicUsize, Condvar, Mutex, Ordering, RwLock,
 };
+use crate::queue::{Injector, Steal};
+use std::{borrow::Cow, fmt, mem, ops, sync::atomic::AtomicIsize, time};
+#[cfg(not(loom))]
+use std::thread;
+#[cfg(loom)]
+use loom::thread;
 
 const BITS_PER_BYTE: usize = 8;
 const MAX_WORKERS: usize = size_of::<usize>() * BITS_PER_BYTE;
@@ -159,7 +160,8 @@ impl<'a> ExecutionContext<'a> {
 
 impl Drop for ExecutionContext<'_> {
     fn drop(&mut self) {
-        if thread::panicking() {
+        #[allow(unused_qualifications)] // loom::thread lacks panicking()
+        if std::thread::panicking() {
             self.choir.issue_panic(self.worker_index);
             let mut guard = self.notifier.continuation.lock().unwrap();
             if let Some(mut cont) = guard.take() {
@@ -225,7 +227,8 @@ pub struct MaybePanic {
 }
 impl Drop for MaybePanic {
     fn drop(&mut self) {
-        if self.worker_index != -1 && !thread::panicking() {
+        #[allow(unused_qualifications)] // loom::thread lacks panicking()
+        if self.worker_index != -1 && !std::thread::panicking() {
             panic!("Panic occurred on worker {}", self.worker_index);
         }
     }
@@ -246,7 +249,7 @@ impl Default for Choir {
         let injector = Injector::new();
         Self {
             injector,
-            condvar: Condvar::default(),
+            condvar: Condvar::new(),
             parked_mask_mutex: Mutex::new(0),
             workers: RwLock::new(WorkerPool {
                 contexts: [NO_WORKER; MAX_WORKERS],
@@ -254,6 +257,19 @@ impl Default for Choir {
             panic_worker: AtomicIsize::new(-1),
         }
     }
+}
+
+#[cfg(not(loom))]
+fn spawn_worker(name: &str, f: impl FnOnce() + Send + 'static) -> thread::JoinHandle<()> {
+    thread::Builder::new()
+        .name(name.to_string())
+        .spawn(f)
+        .unwrap()
+}
+
+#[cfg(loom)]
+fn spawn_worker(_name: &str, f: impl FnOnce() + Send + 'static) -> thread::JoinHandle<()> {
+    thread::spawn(f)
 }
 
 impl Choir {
@@ -274,10 +290,7 @@ impl Choir {
         let worker_clone = Arc::clone(&worker);
         let choir = Arc::clone(self);
 
-        let join_handle = thread::Builder::new()
-            .name(name.to_string())
-            .spawn(move || choir.work_loop(&worker_clone))
-            .unwrap();
+        let join_handle = spawn_worker(name, move || choir.work_loop(&worker_clone));
 
         WorkerHandle {
             worker,
@@ -301,6 +314,10 @@ impl Choir {
     fn schedule(&self, task: Task) {
         log::trace!("Task {} is scheduled", task.notifier);
         self.injector.push(task);
+        // Lock the parked-mask mutex so that a worker that is between
+        // checking `is_empty()` and entering `condvar.wait()` is guaranteed
+        // to receive this notification (same pattern as WorkerHandle::drop).
+        let _guard = self.parked_mask_mutex.lock().unwrap();
         self.condvar.notify_one();
     }
 
@@ -434,12 +451,9 @@ impl Choir {
                     // we handle a race condition between something pushing a task,
                     // and the thread going on the way to sleep.
                     *parked_mask |= mask;
-                    parked_mask = self
-                        .condvar
-                        .wait_while(parked_mask, |_| {
-                            worker.alive.load(Ordering::Acquire) && self.injector.is_empty()
-                        })
-                        .unwrap();
+                    parked_mask = wait_while(&self.condvar, parked_mask, |_| {
+                        worker.alive.load(Ordering::Acquire) && self.injector.is_empty()
+                    });
                     *parked_mask &= !mask;
                 }
                 Steal::Success(task) => {
@@ -717,7 +731,7 @@ impl RunningTask {
             let condvar = Condvar::new();
             cont.waiting_threads
                 .push(WaitingThread { condvar: &condvar });
-            let _guard = condvar.wait_while(guard, |cont| cont.is_some());
+            let _guard = wait_while(&condvar, guard, |cont| cont.is_some());
         }
         self.choir.check_panic()
     }
@@ -768,6 +782,7 @@ impl RunningTask {
 
     /// Block until the task has finished executing, with timeout.
     /// Panics and prints helpful info if the timeout is reached.
+    #[cfg(not(loom))]
     pub fn join_debug(&self, timeout: time::Duration) -> MaybePanic {
         log::debug!("Joining {}", self.notifier);
         let mut guard = self.notifier.continuation.lock().unwrap();
@@ -785,6 +800,12 @@ impl RunningTask {
             }
         }
         self.choir.check_panic()
+    }
+
+    /// Under loom, timeouts are not meaningful — falls back to `join()`.
+    #[cfg(loom)]
+    pub fn join_debug(&self, _timeout: time::Duration) -> MaybePanic {
+        self.join()
     }
 }
 

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -1,0 +1,52 @@
+//! Queue abstraction for crossbeam / loom compatibility.
+//!
+//! Under normal compilation, this re-exports `crossbeam_deque` types.
+//! Under `cfg(loom)`, it provides a simple `Mutex<VecDeque>`-based
+//! replacement so that loom can model the synchronization.
+
+#[cfg(not(loom))]
+pub(crate) use crossbeam_deque::{Injector, Steal};
+
+#[cfg(loom)]
+pub(crate) use self::loom_impl::{Injector, Steal};
+
+#[cfg(loom)]
+mod loom_impl {
+    use loom::sync::Mutex;
+    use std::collections::VecDeque;
+
+    pub(crate) struct Injector<T> {
+        inner: Mutex<VecDeque<T>>,
+    }
+
+    pub(crate) enum Steal<T> {
+        Empty,
+        Success(T),
+        /// Never constructed under loom — exists only for match-arm compatibility.
+        #[allow(dead_code)]
+        Retry,
+    }
+
+    impl<T> Injector<T> {
+        pub fn new() -> Self {
+            Self {
+                inner: Mutex::new(VecDeque::new()),
+            }
+        }
+
+        pub fn push(&self, item: T) {
+            self.inner.lock().unwrap().push_back(item);
+        }
+
+        pub fn steal(&self) -> Steal<T> {
+            match self.inner.lock().unwrap().pop_front() {
+                Some(item) => Steal::Success(item),
+                None => Steal::Empty,
+            }
+        }
+
+        pub fn is_empty(&self) -> bool {
+            self.inner.lock().unwrap().is_empty()
+        }
+    }
+}

--- a/tests/loom.rs
+++ b/tests/loom.rs
@@ -1,0 +1,133 @@
+//! Loom-based concurrency tests for choir.
+//!
+//! Run with: `RUSTFLAGS='--cfg loom' cargo test --test loom --release`
+
+#![cfg(loom)]
+
+use choir::arc::Linearc;
+use loom::sync::atomic::{AtomicUsize, Ordering};
+use loom::sync::Arc;
+use loom::thread;
+
+/// Two threads race to drop a Linearc. Exactly one of them should
+/// cause deallocation; the other must be a no-op.
+#[test]
+fn linearc_concurrent_drop() {
+    loom::model(|| {
+        let a = Linearc::new(42u32);
+        let b = Linearc::clone(&a);
+
+        let t = thread::spawn(move || {
+            drop(b);
+        });
+
+        drop(a);
+        t.join().unwrap();
+    });
+}
+
+/// Two threads race: one calls `into_inner`, the other drops.
+/// Exactly one of them should get the inner value.
+#[test]
+fn linearc_into_inner_race() {
+    loom::model(|| {
+        let a = Linearc::new(7u32);
+        let b = Linearc::clone(&a);
+
+        let got_value = Arc::new(AtomicUsize::new(0));
+        let gv = got_value.clone();
+
+        let t = thread::spawn(move || {
+            if Linearc::into_inner(b).is_some() {
+                gv.fetch_add(1, Ordering::SeqCst);
+            }
+        });
+
+        if Linearc::into_inner(a).is_some() {
+            got_value.fetch_add(1, Ordering::SeqCst);
+        }
+
+        t.join().unwrap();
+        // Exactly one thread should have extracted the value.
+        assert_eq!(got_value.load(Ordering::SeqCst), 1);
+    });
+}
+
+/// Three clones, three threads dropping. Verify no double-free.
+#[test]
+fn linearc_triple_drop() {
+    loom::model(|| {
+        let a = Linearc::new(99u32);
+        let b = Linearc::clone(&a);
+        let c = Linearc::clone(&a);
+
+        let t1 = thread::spawn(move || drop(b));
+        let t2 = thread::spawn(move || drop(c));
+        drop(a);
+
+        t1.join().unwrap();
+        t2.join().unwrap();
+    });
+}
+
+/// `drop_last` race: two threads call `drop_last` on clones.
+/// Exactly one should return `true`.
+#[test]
+fn linearc_drop_last_race() {
+    loom::model(|| {
+        let a = Linearc::new(0u32);
+        let b = Linearc::clone(&a);
+
+        let result = Arc::new(AtomicUsize::new(0));
+        let r = result.clone();
+
+        let t = thread::spawn(move || {
+            if Linearc::drop_last(b) {
+                r.fetch_add(1, Ordering::SeqCst);
+            }
+        });
+
+        if Linearc::drop_last(a) {
+            result.fetch_add(1, Ordering::SeqCst);
+        }
+
+        t.join().unwrap();
+        assert_eq!(result.load(Ordering::SeqCst), 1);
+    });
+}
+
+/// Single task: spawn, execute on a worker, join.
+/// Tests the full schedule → steal → execute → finish → unpark path.
+#[test]
+fn single_task() {
+    loom::model(|| {
+        let choir = choir::Choir::new();
+        let _w = choir.add_worker("W");
+        let flag = Arc::new(AtomicUsize::new(0));
+        let f = flag.clone();
+        choir
+            .spawn("t")
+            .init(move |_| {
+                f.store(1, Ordering::Release);
+            })
+            .run()
+            .join();
+        assert_eq!(flag.load(Ordering::Acquire), 1);
+    });
+}
+
+/// Dummy task with a dependency: B depends on A.
+/// Verifies the Linearc-based dependency resolution.
+#[test]
+fn dependency() {
+    loom::model(|| {
+        let choir = choir::Choir::new();
+        let _w = choir.add_worker("W");
+
+        let mut b = choir.spawn("B").init_dummy();
+        let a = choir.spawn("A").init_dummy();
+        b.depend_on(&a);
+        drop(a); // schedule A via IdleTask::drop
+        b.run().join();
+    });
+}


### PR DESCRIPTION
Summary
	∙	Abstract sync primitives (Mutex, Condvar, RwLock, atomics) behind a cfg(loom) compatibility layer (src/<compat.rs>) so loom can model the synchronization
	∙	Replace crossbeam-deque::Injector with a simple Mutex<VecDeque> under loom (src/<queue.rs>), since crossbeam-deque lacks loom support (crossbeam#849)
	∙	Fix a real race in schedule(): condvar.notify_one() was called without holding parked_mask_mutex, so a notification could be lost if a worker was between checking is_empty() and entering condvar.wait() (same pattern already used in WorkerHandle::drop)
	∙	Add 6 loom tests: Linearc (concurrent drop, into_inner race, triple drop, drop_last) and Choir (single-task execution, dependency resolution)
	∙	Add Loom CI job to pre-merge checks
Test plan
	∙	All 13 existing tests pass (cargo test)
	∙	All 6 loom tests pass (RUSTFLAGS='--cfg loom' cargo test --test loom --release)
	∙	Builds cleanly with and without --cfg loom
	∙	CI runs the new Loom job on Linux