### PR TITLE
Fix 6 soundness and robustness issues from deep audit

### DIFF
--- a/.github/workflows/pre.yaml
+++ b/.github/workflows/pre.yaml
@@ -11,10 +11,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "1.81.0"
+      # Note: only the library is checked. Dev-dependencies (criterion and
+      # its transitive deps like clap) are not bound by the MSRV — they are
+      # never built by library consumers.
       - name: Main check
         run: cargo check --workspace
-      - name: Bench compile check
-        run: cargo bench --no-run
   test:
     name: Test Nightly
     runs-on: ubuntu-latest
@@ -25,6 +26,8 @@ jobs:
         run: cargo test
       - name: Test all
         run: cargo test --workspace
+      - name: Bench compile check
+        run: cargo bench --no-run
   miri:
     name: Miri
     runs-on: ubuntu-latest

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -19,8 +19,8 @@ pub struct Linearc<T: ?Sized> {
     ptr: NonNull<LinearcInner<T>>,
 }
 
-unsafe impl<T: ?Sized> Send for Linearc<T> {}
-unsafe impl<T: ?Sized> Sync for Linearc<T> {}
+unsafe impl<T: ?Sized + Send + Sync> Send for Linearc<T> {}
+unsafe impl<T: ?Sized + Send + Sync> Sync for Linearc<T> {}
 
 impl<T: ?Sized> Linearc<T> {
     #[inline]
@@ -77,7 +77,7 @@ impl<T: ?Sized> Clone for Linearc<T> {
     fn clone(&self) -> Self {
         unsafe { self.ptr.as_ref() }
             .ref_count
-            .fetch_add(1, Ordering::Release);
+            .fetch_add(1, Ordering::Relaxed);
         Self { ptr: self.ptr }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,10 +161,7 @@ impl Drop for ExecutionContext<'_> {
         #[allow(unused_qualifications)] // loom::thread lacks panicking()
         if std::thread::panicking() {
             self.choir.issue_panic(self.worker_index);
-            let mut guard = self.notifier.continuation.lock().unwrap();
-            if let Some(mut cont) = guard.take() {
-                cont.unpark_waiting();
-            }
+            Choir::flush_notifier(self.notifier);
         }
     }
 }
@@ -215,6 +212,16 @@ struct WorkerContext {}
 
 struct WorkerPool {
     contexts: [Option<WorkerContext>; MAX_WORKERS],
+}
+
+struct UnregisterGuard<'a> {
+    choir: &'a Choir,
+    index: usize,
+}
+impl Drop for UnregisterGuard<'_> {
+    fn drop(&mut self) {
+        self.choir.unregister(self.index);
+    }
 }
 
 /// Return type for `join` functions that have to detect panics.
@@ -401,6 +408,8 @@ impl Choir {
                     cont.forks -= 1;
                     return Vec::new();
                 }
+            } else {
+                return Vec::new();
             }
             let mut cont = guard.take().unwrap();
             //Note: this is important to do within the lock,
@@ -437,6 +446,7 @@ impl Choir {
     fn work_loop(self: &Arc<Self>, worker: &Worker) {
         profiling::register_thread!();
         let index = self.register().unwrap();
+        let _unreg = UnregisterGuard { choir: self, index };
         log::info!("Thread[{}] = '{}' started", index, worker.name);
 
         while worker.alive.load(Ordering::Acquire) {
@@ -462,20 +472,34 @@ impl Choir {
         }
 
         log::info!("Thread '{}' dies", worker.name);
-        self.unregister(index);
     }
 
     fn flush_notifier(notifier: &Notifier) {
+        let mut worklist: Vec<Arc<Notifier>> = Vec::new();
+
         let mut guard = notifier.continuation.lock().unwrap();
         if let Some(mut cont) = guard.take() {
+            drop(guard);
             cont.unpark_waiting();
-            for dependent in cont.dependents {
-                if let Some(ready) = Linearc::into_inner(dependent) {
-                    Self::flush_notifier(&ready.notifier);
+            for dep in cont.dependents {
+                if let Some(task) = Linearc::into_inner(dep) {
+                    worklist.push(task.notifier);
                 }
             }
-            for parent in cont.parents {
-                Self::flush_notifier(&parent);
+            worklist.extend(cont.parents);
+        }
+
+        while let Some(n) = worklist.pop() {
+            let mut guard = n.continuation.lock().unwrap();
+            if let Some(mut cont) = guard.take() {
+                drop(guard);
+                cont.unpark_waiting();
+                for dep in cont.dependents {
+                    if let Some(task) = Linearc::into_inner(dep) {
+                        worklist.push(task.notifier);
+                    }
+                }
+                worklist.extend(cont.parents);
             }
         }
     }
@@ -738,6 +762,15 @@ impl RunningTask {
     /// Also, use the current thread to help in the meantime.
     #[profiling::function]
     pub fn join_active(&self) -> MaybePanic {
+        let Some(index) = self.choir.register() else {
+            return self.join();
+        };
+        let _unreg = UnregisterGuard {
+            choir: &self.choir,
+            index,
+        };
+        log::info!("Join thread[{}] started", index);
+
         let condvar;
         match *self.notifier.continuation.lock().unwrap() {
             Some(ref mut cont) => {
@@ -747,8 +780,6 @@ impl RunningTask {
             }
             None => return self.choir.check_panic(),
         }
-        let index = self.choir.register().unwrap();
-        log::info!("Join thread[{}] started", index);
 
         loop {
             let is_done = match self.choir.injector.steal() {
@@ -759,7 +790,7 @@ impl RunningTask {
                         let guard = condvar.wait(guard).unwrap();
                         guard.is_none()
                     } else {
-                        false
+                        true
                     }
                 }
                 Steal::Success(task) => {
@@ -774,7 +805,6 @@ impl RunningTask {
         }
 
         log::info!("Thread[{}] is released", index);
-        self.choir.unregister(index);
         self.choir.check_panic()
     }
 

--- a/tests/audit.rs
+++ b/tests/audit.rs
@@ -1,11 +1,4 @@
-use std::{
-    sync::{
-        atomic::{AtomicUsize, Ordering},
-        Arc,
-    },
-    thread,
-    time::Duration,
-};
+use std::{thread, time::Duration};
 
 /// Finding A: when a task panics, its direct dependents must be unblocked.
 /// Previously, `ExecutionContext::drop` only called `unpark_waiting()` and
@@ -25,7 +18,7 @@ fn panic_unblocks_direct_dependents() {
 
     let (tx, rx) = std::sync::mpsc::channel();
     let b_clone = b_running.clone();
-    thread::spawn(move || {
+    let handle = thread::spawn(move || {
         let mp = b_clone.join();
         let _ = tx.send(());
         std::mem::forget(mp);
@@ -33,6 +26,7 @@ fn panic_unblocks_direct_dependents() {
 
     rx.recv_timeout(Duration::from_secs(5))
         .expect("B must not hang when A panics");
+    handle.join().unwrap();
 }
 
 /// Finding A extended: transitive dependents of a panicking task must also
@@ -54,7 +48,7 @@ fn panic_unblocks_transitive_dependents() {
 
     let (tx, rx) = std::sync::mpsc::channel();
     let c_clone = c_running.clone();
-    thread::spawn(move || {
+    let handle = thread::spawn(move || {
         let mp = c_clone.join();
         let _ = tx.send(());
         std::mem::forget(mp);
@@ -62,40 +56,39 @@ fn panic_unblocks_transitive_dependents() {
 
     rx.recv_timeout(Duration::from_secs(5))
         .expect("C must not hang when A panics transitively");
+    handle.join().unwrap();
 }
 
 /// Finding B: `finish()` must not crash if the continuation was already
 /// taken (e.g., by `flush_notifier` during panic handling).
-/// This test races a normal completion against a panic-triggered flush.
+/// Each iteration uses a fresh choir because panicking workers die.
 #[test]
 fn finish_tolerates_taken_continuation() {
     let _ = env_logger::try_init();
-    let choir = choir::Choir::new();
-    let _w1 = choir.add_worker("W1");
-    let _w2 = choir.add_worker("W2");
 
-    let completed = Arc::new(AtomicUsize::new(0));
+    let iterations = if cfg!(miri) { 2 } else { 10 };
+    for _ in 0..iterations {
+        let choir = choir::Choir::new();
+        let _w1 = choir.add_worker("W1");
+        let _w2 = choir.add_worker("W2");
 
-    for _ in 0..10 {
-        let c = completed.clone();
         let panicker = choir.spawn("panicker").init(|_| {
             panic!("boom");
         });
-        let mut follower = choir.spawn("follower").init(move |_| {
-            c.fetch_add(1, Ordering::Relaxed);
-        });
+        let mut follower = choir.spawn("follower").init(|_| {});
         follower.depend_on(&panicker);
         let r = follower.run();
         drop(panicker);
 
         let (tx, rx) = std::sync::mpsc::channel();
         let rc = r.clone();
-        thread::spawn(move || {
+        let handle = thread::spawn(move || {
             let mp = rc.join();
             let _ = tx.send(());
             std::mem::forget(mp);
         });
         let _ = rx.recv_timeout(Duration::from_secs(2));
+        handle.join().unwrap();
     }
 }
 

--- a/tests/audit.rs
+++ b/tests/audit.rs
@@ -1,0 +1,121 @@
+use std::{
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    thread,
+    time::Duration,
+};
+
+/// Finding A: when a task panics, its direct dependents must be unblocked.
+/// Previously, `ExecutionContext::drop` only called `unpark_waiting()` and
+/// did not walk `dependents`, so tasks blocked on the panicking task would
+/// hang forever.
+#[test]
+fn panic_unblocks_direct_dependents() {
+    let _ = env_logger::try_init();
+    let choir = choir::Choir::new();
+    let _w = choir.add_worker("W");
+
+    let a = choir.spawn("A").init(|_| panic!("boom"));
+    let mut b = choir.spawn("B").init_dummy();
+    b.depend_on(&a);
+    let b_running = b.run();
+    drop(a);
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    let b_clone = b_running.clone();
+    thread::spawn(move || {
+        let mp = b_clone.join();
+        let _ = tx.send(());
+        std::mem::forget(mp);
+    });
+
+    rx.recv_timeout(Duration::from_secs(5))
+        .expect("B must not hang when A panics");
+}
+
+/// Finding A extended: transitive dependents of a panicking task must also
+/// be unblocked (A panics → B is dependent → C depends on B).
+#[test]
+fn panic_unblocks_transitive_dependents() {
+    let _ = env_logger::try_init();
+    let choir = choir::Choir::new();
+    let _w = choir.add_worker("W");
+
+    let a = choir.spawn("A").init(|_| panic!("boom"));
+    let mut b = choir.spawn("B").init_dummy();
+    b.depend_on(&a);
+    let mut c = choir.spawn("C").init_dummy();
+    c.depend_on(&b);
+    let c_running = c.run();
+    drop(b);
+    drop(a);
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    let c_clone = c_running.clone();
+    thread::spawn(move || {
+        let mp = c_clone.join();
+        let _ = tx.send(());
+        std::mem::forget(mp);
+    });
+
+    rx.recv_timeout(Duration::from_secs(5))
+        .expect("C must not hang when A panics transitively");
+}
+
+/// Finding B: `finish()` must not crash if the continuation was already
+/// taken (e.g., by `flush_notifier` during panic handling).
+/// This test races a normal completion against a panic-triggered flush.
+#[test]
+fn finish_tolerates_taken_continuation() {
+    let _ = env_logger::try_init();
+    let choir = choir::Choir::new();
+    let _w1 = choir.add_worker("W1");
+    let _w2 = choir.add_worker("W2");
+
+    let completed = Arc::new(AtomicUsize::new(0));
+
+    for _ in 0..10 {
+        let c = completed.clone();
+        let panicker = choir.spawn("panicker").init(|_| {
+            panic!("boom");
+        });
+        let mut follower = choir.spawn("follower").init(move |_| {
+            c.fetch_add(1, Ordering::Relaxed);
+        });
+        follower.depend_on(&panicker);
+        let r = follower.run();
+        drop(panicker);
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        let rc = r.clone();
+        thread::spawn(move || {
+            let mp = rc.join();
+            let _ = tx.send(());
+            std::mem::forget(mp);
+        });
+        let _ = rx.recv_timeout(Duration::from_secs(2));
+    }
+}
+
+/// Finding C: `Linearc` must require `T: Send + Sync` for `Send`/`Sync`.
+/// This is a compile-time property — the test just verifies that Linearc
+/// with Send+Sync types works correctly at runtime.
+#[test]
+fn linearc_send_sync_bounds() {
+    use choir::arc::Linearc;
+
+    let arc = Linearc::new(42u32);
+    let clone = Linearc::clone(&arc);
+
+    let handle = thread::spawn(move || {
+        assert_eq!(*clone, 42);
+        Linearc::drop_last(clone)
+    });
+
+    let was_last_here = Linearc::drop_last(arc);
+    let was_last_there = handle.join().unwrap();
+    assert!(was_last_here || was_last_there);
+    assert!(!(was_last_here && was_last_there));
+}

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -276,7 +276,7 @@ fn panic_flushes_dependents() {
 
     // Join C on a helper thread so we can apply a timeout.
     let (tx, rx) = std::sync::mpsc::channel();
-    thread::spawn(move || {
+    let handle = thread::spawn(move || {
         let mp = c_running.join();
         let _ = tx.send(());
         // Forget MaybePanic to avoid re-panicking this thread.
@@ -286,4 +286,5 @@ fn panic_flushes_dependents() {
     // If flush_queue doesn't walk dependents, this hangs forever.
     rx.recv_timeout(Duration::from_secs(5))
         .expect("join on C must not hang after panic flushes the queue");
+    handle.join().unwrap();
 }


### PR DESCRIPTION
- (C) Linearc Send/Sync: require T: Send + Sync bounds to prevent unsound sharing of non-thread-safe types
- (C) Linearc clone: use Relaxed ordering (sufficient for refcount increment)
- (B) finish(): handle already-taken continuation gracefully instead of panicking, making it safe against races with flush_notifier
- (A) ExecutionContext::drop: call flush_notifier on panic to transitively unblock dependents, not just waiting threads
- (E) flush_notifier: convert from recursive to iterative worklist to prevent holding MutexGuard across recursive calls and stack overflow
- (D) join_active: register worker pool slot before pushing WaitingThread to prevent dangling pointer on registration failure; fall back to passive join if pool is full; fix infinite loop when task finishes between steal() and lock()
- (F) work_loop/join_active: use UnregisterGuard to ensure pool slot is freed even if the worker thread panics during task execution

https://claude.ai/code/session_01YYaV46Mne3WSJisfcF5VLw