### PR TITLE
Benchmark Linearc against Arc::into_inner

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,10 @@ members = [
 name = "ballpark"
 harness = false
 
+[[bench]]
+name = "refcount_gate"
+harness = false
+
 [dependencies]
 crossbeam-deque = "0.8"
 log = "0.4"

--- a/benches/refcount_gate.rs
+++ b/benches/refcount_gate.rs
@@ -1,0 +1,102 @@
+use choir::arc::Linearc;
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use std::sync::Arc;
+
+const FAN_INS: &[usize] = &[1, 2, 8, 64, 1_024];
+
+fn linearc_sequential(fan_in: usize) -> usize {
+    let root = Linearc::new(black_box(42usize));
+    let mut handles = Vec::with_capacity(fan_in);
+    for _ in 0..fan_in {
+        handles.push(Linearc::clone(&root));
+    }
+    drop(root);
+
+    let mut winners = 0;
+    for handle in handles {
+        if Linearc::into_inner(handle).is_some() {
+            winners += 1;
+        }
+    }
+    winners
+}
+
+fn arc_sequential(fan_in: usize) -> usize {
+    let root = Arc::new(black_box(42usize));
+    let mut handles = Vec::with_capacity(fan_in);
+    for _ in 0..fan_in {
+        handles.push(Arc::clone(&root));
+    }
+    drop(root);
+
+    let mut winners = 0;
+    for handle in handles {
+        if Arc::into_inner(handle).is_some() {
+            winners += 1;
+        }
+    }
+    winners
+}
+
+fn linearc_contended(fan_in: usize) -> usize {
+    let root = Linearc::new(black_box(42usize));
+    let handles = (0..fan_in)
+        .map(|_| Linearc::clone(&root))
+        .collect::<Vec<_>>();
+    drop(root);
+
+    std::thread::scope(|scope| {
+        handles
+            .into_iter()
+            .map(|handle| scope.spawn(move || usize::from(Linearc::into_inner(handle).is_some())))
+            .collect::<Vec<_>>()
+            .into_iter()
+            .map(|thread| thread.join().unwrap())
+            .sum()
+    })
+}
+
+fn arc_contended(fan_in: usize) -> usize {
+    let root = Arc::new(black_box(42usize));
+    let handles = (0..fan_in)
+        .map(|_| Arc::clone(&root))
+        .collect::<Vec<_>>();
+    drop(root);
+
+    std::thread::scope(|scope| {
+        handles
+            .into_iter()
+            .map(|handle| scope.spawn(move || usize::from(Arc::into_inner(handle).is_some())))
+            .collect::<Vec<_>>()
+            .into_iter()
+            .map(|thread| thread.join().unwrap())
+            .sum()
+    })
+}
+
+fn refcount_gate(c: &mut Criterion) {
+    let mut sequential = c.benchmark_group("refcount_gate/sequential");
+    for &fan_in in FAN_INS {
+        sequential.bench_with_input(BenchmarkId::new("linearc", fan_in), &fan_in, |b, &n| {
+            b.iter(|| assert_eq!(black_box(linearc_sequential(n)), 1));
+        });
+        sequential.bench_with_input(BenchmarkId::new("arc_into_inner", fan_in), &fan_in, |b, &n| {
+            b.iter(|| assert_eq!(black_box(arc_sequential(n)), 1));
+        });
+    }
+    sequential.finish();
+
+    let mut contended = c.benchmark_group("refcount_gate/contended");
+    for &fan_in in &[2, 4, 8, 16] {
+        contended.bench_with_input(BenchmarkId::new("linearc", fan_in), &fan_in, |b, &n| {
+            b.iter(|| assert_eq!(black_box(linearc_contended(n)), 1));
+        });
+        contended.bench_with_input(BenchmarkId::new("arc_into_inner", fan_in), &fan_in, |b, &n| {
+            b.iter(|| assert_eq!(black_box(arc_contended(n)), 1));
+        });
+    }
+    contended.finish();
+}
+
+criterion_group!(benches, refcount_gate);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary

Starts the scheduler-audit implementation with an A/B Criterion benchmark comparing Choir's custom `Linearc::into_inner` readiness gate against `std::sync::Arc::into_inner`.

The benchmark covers:
- sequential last-owner extraction at fan-in 1, 2, 8, 64, and 1024
- contended extraction at 2, 4, 8, and 16 threads
- validation that exactly one participant extracts the payload

Run with:

```sh
cargo bench --bench refcount_gate
```

## Why first

This gives us a baseline before replacing `Linearc` in scheduler internals. The following safety work will continue on this branch after the benchmark compiles in CI:

- notifier-owned completion condition variable, removing raw waiter pointers
- active-join wakeup repair
- cross-Choir dependency validation
- ordered `add_fork` locking

## Validation

The changes were written through the GitHub API because the execution sandbox cannot resolve github.com. CI is therefore the first compile and benchmark-build validation for this draft.